### PR TITLE
Update 1045_nth_root.markdown

### DIFF
--- a/1.3.4-_ProcedureFirstClassStatus/1045_nth_root.markdown
+++ b/1.3.4-_ProcedureFirstClassStatus/1045_nth_root.markdown
@@ -90,7 +90,7 @@ Interrupt option (? for help):
 Interrupt option (? for help): 
 ;Up!
 
-1 ]=> (nth-root 32.0 5 4)
+1 ]=> (nth-root 32.0 5 4) 
 
 ;Value: 2.88042559337537
 


### PR DESCRIPTION
this is a mistake. 
1 ]=> (nth-root 32.0 5 2)

;Value: 2.8804315666156364
2 * 2 * 2 * 2 * 2 = 32,not 2.88